### PR TITLE
Refactor inline section into more general instruction frequencies

### DIFF
--- a/proposals/compilation-hints/Overview.md
+++ b/proposals/compilation-hints/Overview.md
@@ -62,15 +62,15 @@ Instruction frequencies are always relative to the surrounding function and ther
 
 For now, we expect annotations to only affect `call`, `call_ref`, `call_indirect` and `loop` instructions. Tools can focus on providing annotations for these instruction to make sure they have the expected impact without unnecessary binary bloat. In the future, this can be extended to more instructions if needed. The structure and the name of this annotation has been specifically chosen to allow for that.
 
-The instruction frequency can be thought of the estimated number of times a callee gets called during one call of the caller. It is a logarithmic value based on the formula $f = \max(1, \min(64, \log_{2} \frac{n}{N} + 32))$ where $n$ is the number of callee calls from this call site and $N$ is the number of caller calls.
+The instruction frequency can be thought of the estimated number of times a callee gets called during one call of the caller. It is a logarithmic value based on the formula $f = \max(1, \min(64, \lfloor \log_{2} \frac{n}{N} \rfloor + 32))$ where $n$ is the total number of executions of this instruction and $N$ is the number of calls to this function.
 
 The main expected use of this hint by engines it to guide inlining decisions. However the actual decision which function should be inlined can be based on runtime data that the engine collected, additional heuristics and available resources. There is no guarantee that a function is or is not inlined, but it should roughly be expected that functions of higher call frequency are prefered over ones with lower frequency.
 Special values of 0 and 127 indicate that a function should never or always be inlined respectively. Engines should respect such annotations over their own heuristics and toolchains should therefore avoid generating such annotations unless there is a good reason for it (e.g. "no inline" annotations in the source).
 
 |binary value|log2 call frequency|calls per parent call|
 |-----------:|------------------:|:-------------------:|
-|           0|                   |*never inline*       |
-|           1|                -31|           <4.657e-10|
+|           0|                   |*cold*               |
+|           1|                -31|           <9.313e-10|
 |           8|                -24|            5.960e-08|
 |          16|                -16|            1.526e-05|
 |          24|                 -8|            0.00391  |
@@ -85,9 +85,7 @@ Special values of 0 and 127 indicate that a function should never or always be i
 |          48|                +16|        65536        |
 |          56|                +24|            1.678e+07|
 |          64|                +32|           >4.295e+09|
-|         127|                   |*always inline*      |
-
-If the *byte offset* is 0, the hint applies to all call sites where the function is the **target**. It serves as a shorthand notation unless explicitly overridden. In this case, the call frequency should be a rough estimate of the average call frequency of all potential sites. *Note: This should likely be moved to a dedicated section for clearer separation, e.g. `metadata.function.inline` if such a namespace will be supported by custom annotations.*
+|         127|                   |*hot*                |
 
 
 ### Call targets

--- a/proposals/compilation-hints/Overview.md
+++ b/proposals/compilation-hints/Overview.md
@@ -105,3 +105,4 @@ The `metadata.code.call_targets` section contains instruction level annotations 
 
 The accumulated call frequency must add up to 100 or less. If it is less than 100, then other call targets that are not listed are responsible for the missing calls. Together with the inline hints on call frequency, this can information can be used to inline function calls as well. The effective call frequency for each call target is then the inlining call frequency multiplied by the fractional call frequency encoded in this section.
 
+Similarly to the compilation order section, not all call sites need to be annotated and not all call targets be listed. However, if other call targets are known but not emitted, then the frequency must be below 100 to inform the engine of the missing information.


### PR DESCRIPTION
This change renames the `inline` section to `instr_freq` and allows such frequencies for arbitrary instructions with the given frequencies applying to all following instructions.

It also changes the convoluted logarithmic scheme to a more transparent log2 based scheme at an acceptable loss of resolution.

This implements the changes requested in issue #8.